### PR TITLE
使用webfont以在移动设备上将右上角的车站名正确显示为宋体

### DIFF
--- a/indexCHS.html
+++ b/indexCHS.html
@@ -73,6 +73,7 @@ Web Font
 <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
 <!-- Google Fonts -->
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400&text=%E7%99%BD%E7%BE%8A%E5%8F%8C%E5%AD%90%E9%AD%94%E7%BE%AF%E6%B0%B4%E7%93%B6%E9%B1%BC%E5%A4%A9%E8%9D%8E%E7%8B%AE%E5%BA%A7%E6%9C%A8%E5%88%B6%E8%A1%97%E9%81%93%E7%AB%99&display=swap" rel="stylesheet">
 
 <!-- YakuHanJPs（約物半角専用のWebフォント　ライセンス：SIL OFL 1.1） -->
 <link href="https://cdn.jsdelivr.net/npm/yakuhanjp@3.3.1/dist/css/yakuhanjp_s.min.css" rel="stylesheet">
@@ -111,7 +112,8 @@ Script
 
 <style>
   body {font-family: YakuHanJPs, "Noto Sans SC", "PingFang SC Regular", "Hiragino Sans GB W3", "Microsoft YaHei", sans-serif;}
-  .train-station__name {font-family: "Noto Serif SC", "Songti SC Regular", STSong, SimSun, serif; font-weight: bold;}
+  .train-station__name {font-family: "Songti SC Regular", STSong, SimSun, "Noto Serif SC", serif;}
+  @media screen and (min-width:999px) {.train-station__name {font-weight: bold;}}
 </style>
 
 </head>


### PR DESCRIPTION
iOS自带柊野明朝体，但不自带任何宋体。因此在不加载外部字体的情况下能正确显示日文衬线体，却不能显示中文衬线体。
除此之外部分非原生Android系统缺少中文衬线字体的fallback，即使在有NotoSerifCJK的情况下也无法正确显示。